### PR TITLE
Strip off Query String

### DIFF
--- a/import-external-attachments.php
+++ b/import-external-attachments.php
@@ -155,7 +155,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 	}
 
 	function is_external_file( $file ) {
-
+                $file = strtok($file, '?'); //strip off querystring
 		$allowed = array( 'jpeg' , 'png', 'bmp' , 'gif',  'pdf', 'jpg', 'doc', 'docx' );
 
 		$ext = pathinfo($file, PATHINFO_EXTENSION);


### PR DESCRIPTION
Addition of   $file = strtok($file, '?'); //strip off querystring   
on line #158 to strip Query strings and allow them to be imported properly.

However, I'd leave it Commented out with instructions in the ReadMe file for uncommenting depending on the users' situation. This will strip attachments imported from Squarespace, Facebook, etc and should be used with caution.